### PR TITLE
added strip() to exclusion check for section headers in paragraphs.

### DIFF
--- a/gatorgrader_fragments.py
+++ b/gatorgrader_fragments.py
@@ -31,7 +31,7 @@ def get_paragraphs(contents, blank_replace=True):
     # disregard all of the section headers in markdown
     matching_paragraphs = []
     for paragraph in paragraphs:
-        if paragraph.startswith(SECTION_MARKER) is False:
+        if paragraph.strip().startswith(SECTION_MARKER) is False:
             matching_paragraphs.append(paragraph)
     return matching_paragraphs
 

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -23,7 +23,7 @@ import gatorgrader_fragments
     ("a\n     ", 1),
     ('# Section Header', 0),
     ('# Section Header\n\nNot Section Header', 1),
-    ('# Section Header\n\n#Something\n\n\n# Section Header\n\nAn actual paragraph', 1),
+    ('Paragraph\n\n\n# Section Header', 1),
 ])
 def test_paragraphs_zero_or_one(writing_string, expected_count):
     """Check that it can detect zero or one paragraphs"""

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -23,6 +23,7 @@ import gatorgrader_fragments
     ("a\n     ", 1),
     ('# Section Header', 0),
     ('# Section Header\n\nNot Section Header', 1),
+    ('# Section Header\n\n#Something\n\n\n# Section Header\n\nAn actual paragraph', 1),
 ])
 def test_paragraphs_zero_or_one(writing_string, expected_count):
     """Check that it can detect zero or one paragraphs"""


### PR DESCRIPTION
When checking paragraph count, a `# Section Header` could be included if it was preceded by an odd number of new line characters. This pull request fixes this issue by striping the whitespace from the paragraph before checking if it starts with the `SECTION_MARKER`. A new test case is also added that fails in the current implementation, but succeeds with the new implementation.