### PR TITLE
Fix code-fence sentence count bug (Issue 17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,11 @@ lib64
 pip-selfcheck.json
 pyvenv.cfg
 
+
+# NLTK #
+######################
+nltk_data
+
 # R #
 ######################
 *-Ex.R

--- a/gatorgrader_fragments.py
+++ b/gatorgrader_fragments.py
@@ -12,9 +12,25 @@ FILE_SEPARATOR = "/"
 
 PARAGRAH_RE = r'(.+?\n\n|.+?$)'
 SECTION_MARKER = "#"
+CODE_FENCE_MARKER = "```"
 GATORGRADER_REPLACEMENT = "GATORGRADER_REPLACEMENT"
 NEWLINE = "\n"
 DOUBLE_NEWLINE = NEWLINE * 2
+
+
+def is_paragraph(candidate):
+    # remove whitespace surrounding candidate paragraph
+    candidate = candidate.strip()
+
+    # if the paragraph is a markdown header, it is not a paragraph
+    if candidate.startswith(SECTION_MARKER):
+        return False
+    # if the paragraph is a fenced code block, it is not a paragraph
+    if candidate.startswith(CODE_FENCE_MARKER):
+        return False
+
+    # if nothing has returned by now, the candidate must be a paragraph
+    return True
 
 
 def get_paragraphs(contents, blank_replace=True):
@@ -31,7 +47,7 @@ def get_paragraphs(contents, blank_replace=True):
     # disregard all of the section headers in markdown
     matching_paragraphs = []
     for paragraph in paragraphs:
-        if paragraph.strip().startswith(SECTION_MARKER) is False:
+        if is_paragraph(paragraph) is True:
             matching_paragraphs.append(paragraph)
     return matching_paragraphs
 

--- a/gatorgrader_fragments.py
+++ b/gatorgrader_fragments.py
@@ -29,6 +29,10 @@ def is_paragraph(candidate):
     if candidate.startswith(CODE_FENCE_MARKER):
         return False
 
+    # there may be other edge cases that should be added here in the
+    # future -- what other structures look like paragraphs but should
+    # not be?
+
     # if nothing has returned by now, the candidate must be a paragraphz
     return True
 

--- a/gatorgrader_fragments.py
+++ b/gatorgrader_fragments.py
@@ -29,7 +29,7 @@ def is_paragraph(candidate):
     if candidate.startswith(CODE_FENCE_MARKER):
         return False
 
-    # if nothing has returned by now, the candidate must be a paragraph
+    # if nothing has returned by now, the candidate must be a paragraphz
     return True
 
 

--- a/gatorgrader_repository.py
+++ b/gatorgrader_repository.py
@@ -9,7 +9,10 @@ MASTER = "master"
 def get_commmits(path):
     """Returns a list of the commits for the repo at path"""
     repository = Repo(path)
-    commits = list(repository.iter_commits(MASTER))
+    # pass in None so that the default (the current branch) is used
+    # this avoids problems with being checked out in different branches
+    # alternatively, we could detect the current HEAD and use that
+    commits = list(repository.iter_commits())
     return commits
 
 

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -24,6 +24,8 @@ import gatorgrader_fragments
     ('# Section Header', 0),
     ('# Section Header\n\nNot Section Header', 1),
     ('Paragraph\n\n\n# Section Header', 1),
+    ('Paragraph\n\n```\nShould not be a paragraph\n```', 1),
+    ('```\nShould not be\na paragraph\n```', 0),
 ])
 def test_paragraphs_zero_or_one(writing_string, expected_count):
     """Check that it can detect zero or one paragraphs"""

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -60,6 +60,11 @@ def test_paragraphs_many(writing_string, expected_count):
      'New one. Question? Fun! Nice!', 4),
     ('The method test.main was called.\nHello world! Example? Writing.\n\n'
      'New one. Question? Fun! Nice!', 4),
+     ('Here is one paragraph.\nIt should end up having three sentences. '
+      'Here is the third sentence\n\n```\nHere\'s a correctly formatted code'
+      ' block that should not be considered as a paragraph to count sentences'
+      ' in.\n```\n\nAnd now here is the second paragraph. It will also '
+      'have three sentences. The third is a short one.', 3),
 ])
 def test_sentences_different_counts(writing_string, expected_count):
     """Check that it can detect different counts of sentences"""

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -60,11 +60,11 @@ def test_paragraphs_many(writing_string, expected_count):
      'New one. Question? Fun! Nice!', 4),
     ('The method test.main was called.\nHello world! Example? Writing.\n\n'
      'New one. Question? Fun! Nice!', 4),
-     ('Here is one paragraph.\nIt should end up having three sentences. '
-      'Here is the third sentence\n\n```\nHere\'s a correctly formatted code'
-      ' block that should not be considered as a paragraph to count sentences'
-      ' in.\n```\n\nAnd now here is the second paragraph. It will also '
-      'have three sentences. The third is a short one.', 3),
+    ('Here is one paragraph.\nIt should end up having three sentences. '
+     'Here is the third sentence\n\n```\nHere\'s a correctly formatted code'
+     ' block that should not be considered as a paragraph to count sentences'
+     ' in.\n```\n\nAnd now here is the second paragraph. It will also '
+     'have three sentences. The third is a short one.', 3),
 ])
 def test_sentences_different_counts(writing_string, expected_count):
     """Check that it can detect different counts of sentences"""

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -26,6 +26,8 @@ import gatorgrader_fragments
     ('Paragraph\n\n\n# Section Header', 1),
     ('Paragraph\n\n```\nShould not be a paragraph\n```', 1),
     ('```\nShould not be\na paragraph\n```', 0),
+    ('Beginning of paragraph ``` Still in fences but now \
+    also in paragraph ``` and end', 1),
 ])
 def test_paragraphs_zero_or_one(writing_string, expected_count):
     """Check that it can detect zero or one paragraphs"""


### PR DESCRIPTION
This is a fix for issue #17. The fix involved adding a method in `gatorgrader_fragments.py` to conduct checks for if a potential paragraph should be counted as one. I then check if the candidate paragraph...

1) begins with `SECTION_HEADER`
2) begins with ```` ``` ````

and if so return false. In all other cases the method returns true. This method is then used to ensure a potential paragraph is actually a paragraph before adding it to the list of paragraphs to return in `gatorgrader_fragments.py:get_paragraphs()`.

Additionally, there was a potential bug in `gatorgrader_repository.py` that was causing the Travis CI build and check to fail. This bug was caused because Travis CI downloads only the branch that was pushed to, however `gatorgrader_repository.py:get_commits()` specifically requests the commits of the `master` branch. This caused a test case to throw an exception, since `master` did not exist on the Travis CI build environment repository. The fix for this was simple: instead of checking `master`, `gatorgrader_repository.py:get_commits()` now returns the commits of the current branch, so that whatever branch is checked out when the method is run is the branch that is used. This should have no side effects during normal use, and now will ensure development or work on different branches can be checked with Travis CI effectively.

As a last note, when writing new `gatorgrader.sh` scripts for class assignments, the author should ensure that the `--start` command only downloads the `master` branch, to ensure no development code accidentally lands on student machines, and introduces the possibility of switching branches.