### PR TITLE
Change sentence check to word count check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,7 +202,7 @@ share/
 lib64
 pip-selfcheck.json
 pyvenv.cfg
-
+.pytest_cache
 
 # NLTK #
 ######################

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,0 +1,4 @@
+{
+  "tests/test_gatorgrader.py": true,
+  "tests/test_gatorgrader_repository.py": true
+}

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,4 +1,0 @@
-{
-  "tests/test_gatorgrader.py": true,
-  "tests/test_gatorgrader_repository.py": true
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
   - pip3 install --upgrade pip
   - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
   - pip3 install flake8
-  - python3 -m nltk.downloader punkt
 
 # set GATORGRADER_HOME environment variable
 before_script:

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ followed by the number of paragraphs to check for in the file.
 
 - `--wordcount`
 
-Indicates to look for a number of words in each paragraph in a Markdown file. Should be followed by
-the number of words to look for.
+Indicates to look for a number of words in each paragraph in a Markdown file.
+Should be followed by the number of words to look for.
 
 - `--fragments`
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ specified with the `--langauge` option.
 Indicates to look for a number of paragraphs in a md file. This should be
 followed by the number of paragraphs to check for in the file.
 
-- `--sentences`
+- `--wordcount`
 
-Indicates to look for a number of sentences in a md file. Should be followed by
-the number of sentences to look for.
+Indicates to look for a number of words in each paragraph in a Markdown file. Should be followed by
+the number of words to look for.
 
 - `--fragments`
 

--- a/gatorgrader.py
+++ b/gatorgrader.py
@@ -41,7 +41,8 @@ def parse_gatorgrader_arguments(args):
     gg_parser.add_argument('--multicomments', nargs='+', type=int)
 
     gg_parser.add_argument('--paragraphs', nargs='+', type=int)
-    gg_parser.add_argument('--wordcount', '--sentences', nargs='+', type=int, dest='wordcount')
+    gg_parser.add_argument('--wordcount', '--sentences', nargs='+', type=int,
+                           dest='wordcount')
 
     gg_parser.add_argument('--fragments', nargs='+', type=str)
     gg_parser.add_argument('--fragmentcounts', nargs='+', type=int)

--- a/gatorgrader.py
+++ b/gatorgrader.py
@@ -41,7 +41,7 @@ def parse_gatorgrader_arguments(args):
     gg_parser.add_argument('--multicomments', nargs='+', type=int)
 
     gg_parser.add_argument('--paragraphs', nargs='+', type=int)
-    gg_parser.add_argument('--sentences', nargs='+', type=int)
+    gg_parser.add_argument('--wordcount', '--sentences', nargs='+', type=int, dest='wordcount')
 
     gg_parser.add_argument('--fragments', nargs='+', type=str)
     gg_parser.add_argument('--fragmentcounts', nargs='+', type=int)
@@ -77,7 +77,7 @@ def verify_gatorgrader_arguments(args):
     elif args.paragraphs is not None:
         if args.checkfiles is None or args.directories is None:
             verified_arguments = False
-    elif args.sentences is not None:
+    elif args.wordcount is not None:
         if args.checkfiles is None or args.directories is None:
             verified_arguments = False
     elif args.fragments is None and args.fragmentcounts is not None:
@@ -169,12 +169,12 @@ if __name__ == '__main__':
                         gg_arguments.checkfiles, gg_arguments.directories,
                         gg_arguments.paragraphs)
                 check_return_values.extend(current_invoke_return_values)
-            # CHECK: Writing all paragraphs contain 'k' sentences
-            if gg_arguments.sentences is not None:
+            # CHECK: Writing all paragraphs contain 'k' words
+            if gg_arguments.wordcount is not None:
                 current_invoke_return_values =\
-                    gatorgrader_invoke.invoke_all_sentence_checks(
+                    gatorgrader_invoke.invoke_all_word_count_checks(
                         gg_arguments.checkfiles, gg_arguments.directories,
-                        gg_arguments.sentences)
+                        gg_arguments.word_count)
                 check_return_values.extend(current_invoke_return_values)
             # CHECK: Content contains 'k' specified fragments
             if (gg_arguments.fragments is not None and

--- a/gatorgrader.py
+++ b/gatorgrader.py
@@ -175,7 +175,7 @@ if __name__ == '__main__':
                 current_invoke_return_values =\
                     gatorgrader_invoke.invoke_all_word_count_checks(
                         gg_arguments.checkfiles, gg_arguments.directories,
-                        gg_arguments.word_count)
+                        gg_arguments.wordcount)
                 check_return_values.extend(current_invoke_return_values)
             # CHECK: Content contains 'k' specified fragments
             if (gg_arguments.fragments is not None and

--- a/gatorgrader_fragments.py
+++ b/gatorgrader_fragments.py
@@ -67,14 +67,12 @@ def count_words(contents):
     # retrieve all of the paragraphs in the contents
     replace_blank_inputs = False
     paragraphs = get_paragraphs(contents, replace_blank_inputs)
-    print(paragraphs)
     # count all of the words in each paragraph
     word_counts = []
     for para in paragraphs:
         para = para.replace("\n", " ")
         words = "".join(ch if ch.isalnum() else " " for ch in para).split()
         word_counts.append(len(words))
-    print(word_counts)
     return min(word_counts)
 
 

--- a/gatorgrader_fragments.py
+++ b/gatorgrader_fragments.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 import re
-import nltk
 
 FILE_SEPARATOR = "/"
 
@@ -63,18 +62,18 @@ def count_paragraphs(contents):
     return len(matching_paragraphs)
 
 
-def count_sentences(contents):
+def count_words(contents):
     """Counts the number of sentences in the writing"""
     # retrieve all of the paragraphs in the contents
     replace_blank_inputs = False
     paragraphs = get_paragraphs(contents, replace_blank_inputs)
     # count all of the sentences in each paragraph
-    sentence_counts = []
-    for paragraph in paragraphs:
-        paragraph = paragraph.replace("\n", " ")
-        sentences = nltk.sent_tokenize(paragraph)
-        sentence_counts.append(len(sentences))
-    return min(sentence_counts)
+    word_counts = []
+    for para in paragraphs:
+        para = para.replace("\n", " ")
+        words = "".join(ch if ch.isalnum() else " " for ch in para).split()
+        word_counts.append(len(words))
+    return min(word_counts)
 
 
 def count_specified_fragment(contents, fragment):

--- a/gatorgrader_fragments.py
+++ b/gatorgrader_fragments.py
@@ -63,16 +63,18 @@ def count_paragraphs(contents):
 
 
 def count_words(contents):
-    """Counts the number of sentences in the writing"""
+    """Counts the number of words in the writing"""
     # retrieve all of the paragraphs in the contents
     replace_blank_inputs = False
     paragraphs = get_paragraphs(contents, replace_blank_inputs)
-    # count all of the sentences in each paragraph
+    print(paragraphs)
+    # count all of the words in each paragraph
     word_counts = []
     for para in paragraphs:
         para = para.replace("\n", " ")
         words = "".join(ch if ch.isalnum() else " " for ch in para).split()
         word_counts.append(len(words))
+    print(word_counts)
     return min(word_counts)
 
 

--- a/gatorgrader_invoke.py
+++ b/gatorgrader_invoke.py
@@ -139,9 +139,9 @@ def invoke_all_paragraph_checks(files, directories, expected_counts):
     return was_exceeded_list
 
 
-def invoke_all_sentence_checks(files, directories, expected_counts):
+def invoke_all_word_count_checks(files, directories, expected_counts):
     """Repeatedly perform the check and return the results"""
-    print("Checking for sentences...")
+    print("Checking for word counts...")
     print()
     was_exceeded_list = []
     met_or_exceeded_count = 0
@@ -159,12 +159,12 @@ def invoke_all_sentence_checks(files, directories, expected_counts):
             directory,
             " have paragraphs with at least ",
             expected_count,
-            " sentence(s)? ",
+            " words? ",
             gatorgrader_util.get_human_answer(met_or_exceeded_count),
             sep="")
 
     print()
-    print("... Done checking for sentences")
+    print("... Done checking for word counts")
     return was_exceeded_list
 
 

--- a/gatorgrader_invoke.py
+++ b/gatorgrader_invoke.py
@@ -149,7 +149,7 @@ def invoke_all_sentence_checks(files, directories, expected_counts):
                                                     expected_counts):
         met_or_exceeded_count = gatorgrader_entities.entity_greater_than_count(
             filecheck, directory, expected_count,
-            gatorgrader_fragments.count_sentences)
+            gatorgrader_fragments.count_words)
 
         was_exceeded_list.append(met_or_exceeded_count)
         print(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 coverage==4.4.2
 gitdb2==2.0.3
 GitPython==2.1.8
-nltk==3.2.5
 pathlib==1.0.1
 py==1.4.34
 pytest==3.2.1

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -56,7 +56,7 @@ def test_paragraphs_many(writing_string, expected_count):
     ('The method test.main was called. Hello world! Writing a lot.\n\n'
      'New one. Question? Fun!', 4),
     ('New one. Question? Fun! Nice!\n\n'
-    'The method test.main was called. Hello world! Writing a lot.', 5),
+     'The method test.main was called. Hello world! Writing a lot.', 5),
     ('The method `test.main` was called. Hello world! Example? Writing.\n\n'
      'New one. Question? Fun! Nice!', 5),
     ('The method test.main was called.\nHello world! Example? Writing.\n\n'

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -61,10 +61,12 @@ def test_paragraphs_many(writing_string, expected_count):
     ('The method test.main was called.\nHello world! Example? Writing.\n\n'
      'New one. Question? Fun! Nice!', 4),
     ('Here is one paragraph.\nIt should end up having three sentences. '
-     'Here is the third sentence\n\n```\nHere\'s a correctly formatted code'
-     ' block that should not be considered as a paragraph to count sentences'
-     ' in.\n```\n\nAnd now here is the second paragraph. It will also '
+     'Here is the third sentence\n\n```\nHere\'s a correctly formatted code '
+     'block that should not be considered as a paragraph to count sentences '
+     'in.\n```\n\nAnd now here is the second paragraph. It will also '
      'have three sentences. The third is a short one.', 3),
+    ('This is a paragraph with A through L in it. It should pass. '
+     'It should also have three sentences', 3),
 ])
 def test_sentences_different_counts(writing_string, expected_count):
     """Check that it can detect different counts of sentences"""

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -50,29 +50,24 @@ def test_paragraphs_many(writing_string, expected_count):
 
 
 @pytest.mark.parametrize("writing_string,expected_count", [
-    ('hello world! Writing a lot.\n\nnew one.', 1),
-    ('hello world! Writing a lot.\n\nNew one. Question?', 2),
+    ('hello world! Writing a lot.\n\nsingle.', 1),
+    ('hello world! Writing a lot.\n\nnew one.', 2),
+    ('hello world! Writing a lot.\n\nNew one. Question?', 3),
     ('The method test.main was called. Hello world! Writing a lot.\n\n'
-     'New one. Question? Fun!', 3),
-    ('The method test.main was called. Hello world! Writing a lot.\n\n'
-     'New one. Question? Fun! Nice!', 3),
-    ('The method test.main was called. Hello world! Example? Writing.\n\n'
-     'New one. Question? Fun! Nice!', 4),
+     'New one. Question? Fun!', 4),
+    ('New one. Question? Fun! Nice!\n\n'
+    'The method test.main was called. Hello world! Writing a lot.', 5),
+    ('The method `test.main` was called. Hello world! Example? Writing.\n\n'
+     'New one. Question? Fun! Nice!', 5),
     ('The method test.main was called.\nHello world! Example? Writing.\n\n'
-     'New one. Question? Fun! Nice!', 4),
-    ('Here is one paragraph.\nIt should end up having three sentences. '
-     'Here is the third sentence\n\n```\nHere\'s a correctly formatted code '
-     'block that should not be considered as a paragraph to count sentences '
-     'in.\n```\n\nAnd now here is the second paragraph. It will also '
-     'have three sentences. The third is a short one.', 3),
-    ('This is a paragraph with A through L in it. It should pass.\n'
-     'It should also have three sentences', 3),
-    ('This is a sentence ending in A through L. It should also pass.\n'
-     'The paragraph should have three sentences', 3),
+     'New one. Question? Fun! Nice!', 5),
+    ('Here is some code in a code block.\n\n```\ndef test_function():\n    '
+     'function_call()\n```\n\nHello world! Example? Writing.\n\n'
+     'New one. Question? Fun! Nice!', 8),
 ])
-def test_sentences_different_counts(writing_string, expected_count):
+def test_words_different_counts(writing_string, expected_count):
     """Check that it can detect different counts of sentences"""
-    assert gatorgrader_fragments.count_sentences(
+    assert gatorgrader_fragments.count_words(
         writing_string) == expected_count
 
 

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -67,6 +67,8 @@ def test_paragraphs_many(writing_string, expected_count):
      'have three sentences. The third is a short one.', 3),
     ('This is a paragraph with A through L in it. It should pass. '
      'It should also have three sentences', 3),
+     ('This is a sentence ending in A through L. It should also pass. '
+      'The paragraph should have three sentences', 3),
 ])
 def test_sentences_different_counts(writing_string, expected_count):
     """Check that it can detect different counts of sentences"""

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -65,10 +65,10 @@ def test_paragraphs_many(writing_string, expected_count):
      'block that should not be considered as a paragraph to count sentences '
      'in.\n```\n\nAnd now here is the second paragraph. It will also '
      'have three sentences. The third is a short one.', 3),
-    ('This is a paragraph with A through L in it. It should pass. '
+    ('This is a paragraph with A through L in it. It should pass.\n'
      'It should also have three sentences', 3),
-     ('This is a sentence ending in A through L. It should also pass. '
-      'The paragraph should have three sentences', 3),
+    ('This is a sentence ending in A through L. It should also pass.\n'
+     'The paragraph should have three sentences', 3),
 ])
 def test_sentences_different_counts(writing_string, expected_count):
     """Check that it can detect different counts of sentences"""

--- a/tests/test_gatorgrader_fragments.py
+++ b/tests/test_gatorgrader_fragments.py
@@ -63,10 +63,10 @@ def test_paragraphs_many(writing_string, expected_count):
      'New one. Question? Fun! Nice!', 5),
     ('Here is some code in a code block.\n\n```\ndef test_function():\n    '
      'function_call()\n```\n\nHello world! Example? Writing.\n\n'
-     'New one. Question? Fun! Nice!', 8),
+     'New one. Question? Fun! Nice!', 4),
 ])
 def test_words_different_counts(writing_string, expected_count):
-    """Check that it can detect different counts of sentences"""
+    """Check that it can detect different counts of words"""
     assert gatorgrader_fragments.count_words(
         writing_string) == expected_count
 


### PR DESCRIPTION
This merge will change the `--sentences` check to a `--wordcount` check. The new `--wordcount` check simply checks that there at at minimum `k` words in each paragraph when k is given as `--wordcount k`. This check works exactly the same as the old `--sentences` check, and uses much of the same logic and code. To preserve backwards compatibility, `--sentences` is now an alias for `--wordcount`, so old checking commands will still work, although will check for `k` words instead of `k` sentences.

This merge also obviates the need for nltk as a dependency, and therefore nltk was removed from `requirements.txt`. This branch was also tested extensively in actual use with student and solution repositories to ensure both backward and forward compatibility. This merge should have no effect on old assignments, besides the fact that the sentence check will no longer work as expected. In the future, the `--sentences` option may be deprecated, so as to remove any confusion - it is already removed from the documentation.